### PR TITLE
Add basic support for SSE GET1 Nodes.

### DIFF
--- a/BrawlLib/BrawlLib.csproj
+++ b/BrawlLib/BrawlLib.csproj
@@ -176,6 +176,7 @@
     <Compile Include="SSBB\ResourceNodes\BrawlEx\RSTCNode.cs" />
     <Compile Include="SSBB\ResourceNodes\BrawlEx\SLTCNode.cs" />
     <Compile Include="SSBB\ResourceNodes\Subspace\Animation\GCAMNode.cs" />
+    <Compile Include="SSBB\ResourceNodes\Subspace\GET1Node.cs" />
     <Compile Include="SSBB\ResourceNodes\Subspace\Hazards\GWATNode.cs" />
     <Compile Include="SSBB\ResourceNodes\Subspace\Hazards\GFG1Node.cs" />
     <Compile Include="SSBB\ResourceNodes\Subspace\Navigation\GDBFNode.cs" />
@@ -187,6 +188,7 @@
     <Compile Include="SSBB\Types\BrawlEx\RSTC.cs" />
     <Compile Include="SSBB\Types\BrawlEx\SLTC.cs" />
     <Compile Include="SSBB\Types\Subspace\Animation\GCAM.cs" />
+    <Compile Include="SSBB\Types\Subspace\GET1.cs" />
     <Compile Include="SSBB\Types\Subspace\Hazards\GWAT.cs" />
     <Compile Include="SSBB\Types\Subspace\Hazards\GFG1.cs" />
     <Compile Include="SSBB\Types\Subspace\Navigation\GDBF.cs" />

--- a/BrawlLib/SSBB/ResourceNodes/Subspace/BLOCNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/BLOCNode.cs
@@ -60,6 +60,7 @@ namespace BrawlLib.SSBB.ResourceNodes
         {
             BLOC* header = (BLOC*)address;
             *header = new BLOC();
+            header->_tag = BLOC.Tag;
             header->_count = Children.Count;
             header->_version = Version;
             header->_extParam = ExtParam;

--- a/BrawlLib/SSBB/ResourceNodes/Subspace/GET1Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Subspace/GET1Node.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using BrawlLib.SSBBTypes;
+
+namespace BrawlLib.SSBB.ResourceNodes
+{
+    public unsafe class GET1Node : ResourceNode
+    {
+        internal protected GET1* Header { get { return (GET1*)WorkingUncompressed.Address; } }
+
+        public override bool OnInitialize()
+        {
+            if (_name == null)
+                _name = "Area Triggers";
+
+            return Header->_entryCount > 0;
+        }
+        public override void OnPopulate()
+        {
+            for (int i = 0; i < Header->_entryCount; i++)
+            {
+                DataSource source;
+                if (i == Header->_entryCount - 1)
+                    source = new DataSource((*Header)[i], WorkingUncompressed.Address + WorkingUncompressed.Length - (*Header)[i]);
+                else
+                    source = new DataSource((*Header)[i], (*Header)[i + 1] - (*Header)[i]);
+
+                new GET1EntryNode().Initialize(this, source);
+            }
+        }
+        public override int OnCalculateSize(bool force)
+        {
+            return GET1.SIZE + (Children.Count * 4) + (Children.Count * GET1Entry.SIZE);
+        }
+        public override void OnRebuild(VoidPtr address, int length, bool force)
+        {
+            GET1* header = (GET1*)address;
+            *header = new GET1();
+            header->_tag = GET1.TAG;
+            header->_entryCount = Children.Count;
+
+            uint offset = (uint)(0x08 + (Children.Count * 4));
+            for (int i = 0; i < Children.Count; i++)
+            {
+                if (i > 0)
+                    offset += (uint)(Children[i - 1].CalculateSize(false));
+
+                *(buint*)((VoidPtr)address + 0x08 + i * 4) = offset;
+                _children[i].Rebuild((VoidPtr)address + offset, _children[i].CalculateSize(false), true);
+            }
+        }
+
+        internal static ResourceNode TryParse(DataSource source) { return ((GET1*)source.Address)->_tag == GET1.TAG ? new GET1Node() : null; }
+    }
+
+    public unsafe class GET1EntryNode : ResourceNode
+    {
+        internal protected GET1Entry* Entry { get { return (GET1Entry*)WorkingUncompressed.Address; } }
+
+        [Category("General")]
+        [DisplayName("Actvation Coord 1")]
+        [TypeConverter(typeof(Vector2fTypeConverter))]
+        public Vector2 Point1
+        {
+            get { return _p1; }
+            set { _p1 = value; SignalPropertyChange(); }
+        }
+        private Vector2 _p1 = new Vector2();
+
+        [Category("General")]
+        [DisplayName("Actvation Coord 2")]
+        [TypeConverter(typeof(Vector2fTypeConverter))]
+        public Vector2 Point2
+        {
+            get { return _p2; }
+            set { _p2 = value; SignalPropertyChange(); }
+        }
+        private Vector2 _p2 = new Vector2();
+
+        [Category("Triggers")]
+        [DisplayName("Trigger1")]
+        [TypeConverter(typeof(UInt32HexTypeConverter))]
+        public uint Trigger { get { return _trigger1; } set { _trigger1 = value; SignalPropertyChange(); } }
+        private uint _trigger1 = 0x0;
+
+        [Category("Triggers")]
+        [DisplayName("Trigger2")]
+        [TypeConverter(typeof(UInt32HexTypeConverter))]
+        public uint Trigger2 { get { return _trigger2; } set { _trigger2 = value; SignalPropertyChange(); } }
+        private uint _trigger2 = 0x0;
+
+        public override bool OnInitialize()
+        {
+            if (_name == null)
+                _name = $"Area[{Index}]";
+
+            _trigger1 = Entry->_trigger1;
+            _p1 = new Vector2(Entry->_x1, Entry->_y1);
+            _p2 = new Vector2(Entry->_x2, Entry->_y2);
+            _trigger2 = Entry->_trigger2;
+
+            return false;
+        }
+        public override int OnCalculateSize(bool force)
+        {
+            return GET1Entry.SIZE;
+        }
+        public override void OnRebuild(VoidPtr address, int length, bool force)
+        {
+            GET1Entry* header = (GET1Entry*)address;
+            *header = new GET1Entry();
+            header->_trigger1 = Trigger;
+            header->_x1 = Point1._x;
+            header->_y1 = Point1._y;
+            header->_x2 = Point2._x;
+            header->_y2 = Point2._y;
+            header->_trigger2 = Trigger2;
+        }
+    }
+}

--- a/BrawlLib/SSBB/Types/Subspace/GET1.cs
+++ b/BrawlLib/SSBB/Types/Subspace/GET1.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace BrawlLib.SSBBTypes
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public unsafe struct GET1
+    {
+        public const uint TAG = 0x31544547; //GET1
+        public const int SIZE = 0x8;
+
+        public uint _tag;
+        public bint _entryCount;
+
+        public VoidPtr this[int index] { get { return (VoidPtr)((byte*)Address + Offsets(index)); } }
+        public uint Offsets(int index) { return *(buint*)((byte*)Address + 0x08 + (index * 4)); }
+        private VoidPtr Address { get { fixed (void* ptr = &this) return ptr; } }
+    }
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public unsafe struct GET1Entry
+    {
+        public const int SIZE = 0x18;
+
+        public buint _trigger1;
+        public bfloat _x1;
+        public bfloat _y1;
+        public bfloat _x2;
+        public bfloat _y2;
+        public buint _trigger2;
+    }
+}

--- a/BrawlLib/System/TypeConverters.cs
+++ b/BrawlLib/System/TypeConverters.cs
@@ -54,4 +54,122 @@ namespace System
             return s.Substring(s.LastIndexOf('.') + 1);
         }
     }
+
+    internal class UInt32HexTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+            else
+            {
+                return base.CanConvertFrom(context, sourceType);
+            }
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return true;
+            }
+            else
+            {
+                return base.CanConvertTo(context, destinationType);
+            }
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value.GetType() == typeof(UInt32))
+            {
+                return $"0x{value:X8}";
+            }
+            else
+            {
+                return base.ConvertTo(context, culture, value, destinationType);
+            }
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value.GetType() == typeof(string))
+            {
+                string input = (string)value;
+
+                if (input.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                {
+                    input = input.Substring(2);
+                }
+
+                return UInt32.Parse(input, System.Globalization.NumberStyles.HexNumber, culture);
+            }
+            else
+            {
+                return base.ConvertFrom(context, culture, value);
+            }
+        }
+    }
+    internal class Vector2fTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+            else
+            {
+                return base.CanConvertFrom(context, sourceType);
+            }
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return true;
+            }
+            else
+            {
+                return base.CanConvertTo(context, destinationType);
+            }
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value.GetType() == typeof(Vector2))
+            {
+                var vec = (Vector2)value;
+                return $"({vec._x},{vec._y})";
+            }
+            else
+            {
+                return base.ConvertTo(context, culture, value, destinationType);
+            }
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value.GetType() == typeof(string))
+            {
+                string input = (string)value;
+                if (input.StartsWith("(", StringComparison.OrdinalIgnoreCase))
+                {
+                    input = input.Trim(new char[] { '(', ')' });
+                }
+
+                var f1 = input.Substring(0, input.IndexOf(',')).Trim();
+                var f2 = input.Substring(input.IndexOf(",")+1, input.Length - (input.IndexOf(",")+1));
+
+                return new Vector2(float.Parse(f1), float.Parse(f2));
+            }
+            else
+            {
+                return base.ConvertFrom(context, culture, value);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds support for basic editing of SSE GET1 Nodes (Area Triggers). Fully editable and rebuild-able.

Also adds a few new typeconverter classes to Brawllib for facilitating propertygrid editing of hex numbers and Vector2 types. 