### PR TITLE
Minor REL tweaks and crash fix

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/Modules/RELNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Modules/RELNode.cs
@@ -122,6 +122,10 @@ namespace BrawlLib.SSBB.ResourceNodes
         [Category("Relocatable Module")]
         public uint FixSize { get { return _fixSize; } }
 
+        [Category("Relocatable Module")]
+        [DisplayName("Imported Modules")]
+        public string[] ImportedModules { get; private set; }
+
         #region Stage module conversion - designer properties
         [Category("Brawl Stage Module")]
         [TypeConverter(typeof(DropDownListStageRelIDs))]
@@ -250,11 +254,13 @@ namespace BrawlLib.SSBB.ResourceNodes
             _fixSize = Header->_commandOffset;
 
             _imports = new SortedDictionary<uint, List<RELLink>>();
+            ImportedModules = new string[Header->ImportListCount];
             for (int i = 0; i < Header->ImportListCount; i++)
             {
-                RELImportEntry* entry = (RELImportEntry*)&Header->Imports[i];
+                RELImportEntry* entry = &Header->Imports[i];
                 uint id = (uint)entry->_moduleId;
                 _imports.Add(id, new List<RELLink>());
+                ImportedModules[i] = _idNames.ContainsKey(id) ? _idNames[id] : $"Module{id:X}";
 
                 RELLink* link = (RELLink*)(WorkingUncompressed.Address + (uint)entry->_offset);
                 do { _imports[id].Add(*link); }

--- a/BrawlLib/SSBB/ResourceNodes/Modules/RELObjectParser.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Modules/RELObjectParser.cs
@@ -45,6 +45,9 @@ namespace BrawlLib.SSBB.ResourceNodes
                 return null;
 
             uint relOffset = cmd.Apply(Manager.GetUint(index), 0);
+            if (relOffset > _objectSection._dataOffset + _objectSection._dataSize)
+                return null;
+
             string name = new string((sbyte*)(_objectSection.Header + relOffset));
 
             if (String.IsNullOrWhiteSpace(name))

--- a/BrawlLib/SSBB/ResourceNodes/Modules/RELSectionNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Modules/RELSectionNode.cs
@@ -54,10 +54,13 @@ namespace BrawlLib.SSBB.ResourceNodes
                 _isBSSSection = false;
                 InitBuffer(_dataSize, Header);
                 if (Index == 5)
+                {
                     _parser = new ObjectParser(this);
+                    return true;
+                }
             }
 
-            return _parser != null;
+            return false;
         }
         public override void OnPopulate()
         {


### PR DESCRIPTION
Prevents crashing when section[5] isn't the Object section or when it doesn't contain any valid Objects. This PR also adds displaying the list of imported modules for informational purposes.